### PR TITLE
✨ Create Wordpress project info migration tool

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,274 @@
+# Top-level config file
+root = true
+
+# All files
+[*]
+indent_style = space
+
+[*.yml]
+indent_size = 2
+
+[*.md]
+charset = utf-8
+insert_final_newline = true
+end_of_line = unset # Leave it to git
+indent_style = space
+indent_size = 2
+max_line_length = 80
+
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# Generic C# files
+[*.{cs,vb}]
+
+## Generic options
+charset = utf-8-bom
+indent_size = 4
+indent_style = space
+tab_width = 8
+trim_trailing_whitespace = true
+end_of_line = unset # Leave it to git
+insert_final_newline = true
+
+## .NET style rules
+### Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+file_header_template = unset # too long to set here
+
+### this. and Me. qualifiers
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+
+### Language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access = true:warning
+
+### Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+dotnet_diagnostic.SA1400.severity = warning # it doesn't follow the above value
+dotnet_style_readonly_field = true:warning
+
+### Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
+
+### Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:warning
+dotnet_style_prefer_conditional_expression_over_return = true:warning
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:warning
+dotnet_style_prefer_simplified_boolean_expressions = true:warning
+dotnet_style_operator_placement_when_wrapping = end_of_line
+
+### Null-checking preferences
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+
+### Unnecessary code rules
+dotnet_code_quality_unused_parameters = all:warning
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+## C# style rules
+### var preferences
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+dotnet_diagnostic.IDE0008.severity = suggestion # Doesn't follow above values
+
+### Expression-bodied members
+csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
+csharp_style_expression_bodied_properties = when_on_single_line:suggestion
+csharp_style_expression_bodied_indexers = when_on_single_line:suggestion
+csharp_style_expression_bodied_accessors = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = when_on_single_line:suggestion
+
+### Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
+csharp_style_prefer_not_pattern = true:warning
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+
+### Expression-level preferences
+csharp_style_inlined_variable_declaration = true:warning
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_prefer_index_operator = true:warning
+csharp_style_prefer_range_operator = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:warning
+csharp_style_unused_value_expression_statement_preference = discard_variable:suggestion
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+
+### Null-checking preferences
+csharp_style_throw_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+
+### Code-block preferences
+csharp_prefer_braces = true:warning
+dotnet_diagnostic.SA1503.severity = warning # Doesn't follow above value
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+
+### 'using' directive preferences
+csharp_using_directive_placement = inside_namespace:warning
+dotnet_diagnostic.SA1200.severity = warning # Doesn't follow above value
+
+### Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+
+### New C# features
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
+
+## C# formatting rules
+### New line preferences
+csharp_new_line_before_open_brace = methods,types
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_finally = false
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+### Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+csharp_style_namespace_declarations = file_scoped
+
+### Spacing preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+
+### Wrapping preferences
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+### Top level statement
+csharp_style_prefer_top_level_statements = true:silent
+
+## Naming styles rules
+dotnet_style_namespace_match_folder = true:warning
+dotnet_diagnostic.IDE1006.severity = warning
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = warning
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = warning
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+### Symbol specifications
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+## Code analyzers
+### .NET SDK
+dotnet_diagnostic.CA1303.severity = none # We don't translate exception and log messages from English
+dotnet_diagnostic.SA1025.severity = none # Allow spaces in comments to structure info
+dotnet_diagnostic.IDE0045.severity = suggestion # Simplify ifs
+dotnet_diagnostic.IDE0046.severity = suggestion # Simplify ifs
+dotnet_diagnostic.IDE0057.severity = suggestion # Slice can be simplified
+
+### StyleCop
+dotnet_diagnostic.SA1101.severity = none # Do not force to prefix local calls with 'this'
+dotnet_diagnostic.SA1204.severity = suggestion # Static methods should be before non-static
+dotnet_diagnostic.SA1500.severity = none # Allow inline braces
+dotnet_diagnostic.SA1633.severity = none # No XML-format header in source files
+
+### SonarAnalyzer
+dotnet_diagnostic.S1133.severity = suggestion # Remove deprecated code -.-' I know, some day
+dotnet_diagnostic.S1135.severity = suggestion # It's almost inevitable to have TODO but add bug ID
+
+# Special rules for test projects
+[src/*Tests/**]
+dotnet_diagnostic.CS1591.severity = none # Disable documentation
+dotnet_diagnostic.CA1001.severity = none # No need to implement IDisposable in test classes with cleanup.
+dotnet_diagnostic.CA1034.severity = none # Public types in test classes for testing implementations
+dotnet_diagnostic.CA1040.severity = none # Empty interfaces for testing
+dotnet_diagnostic.CA1062.severity = none # No need to validate args in test methods
+dotnet_diagnostic.CA1305.severity = none # No culture method for quick test code
+dotnet_diagnostic.CA1307.severity = none # No culture method for quick test code
+dotnet_diagnostic.SA0001.severity = none # Disable documentation
+dotnet_diagnostic.SA1600.severity = none # Disable documentation
+dotnet_diagnostic.SA1601.severity = none # Disable documentation
+dotnet_diagnostic.SA1602.severity = none # Disable documentation
+dotnet_diagnostic.SA1201.severity = none # Allow enums inside classes
+dotnet_diagnostic.S1144.severity = none # Remove unused setter
+dotnet_diagnostic.S2094.severity = none # Remove empty class
+dotnet_diagnostic.S2699.severity = none # Assert may be in helper methods
+dotnet_diagnostic.S3966.severity = none # Dispose twice to test implementation
+dotnet_code_quality_unused_parameters = all:none # Some test methods may not use all the source args

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 log/
 coverage/
 Gemfile.lock
+
+bin/
+obj/
+.vs/

--- a/tools/TraduSquare.Web.Rest.Client/ProjectHandler.cs
+++ b/tools/TraduSquare.Web.Rest.Client/ProjectHandler.cs
@@ -24,9 +24,10 @@ public class ProjectHandler
         
     }
 
-    public async Task<IEnumerable<CreateProjectResponse>> GetAll()
+    public async Task<IndexProjectResponse?> GetAll()
     {
-        throw new NotImplementedException();
+        var request = new RestRequest("/projects", Method.Get);
+        return await client.GetAsync<IndexProjectResponse?>(request);
     }
 
     public async Task<CreateProjectResponse?> Get(string projectUrl)

--- a/tools/TraduSquare.Web.Rest.Client/ProjectHandler.cs
+++ b/tools/TraduSquare.Web.Rest.Client/ProjectHandler.cs
@@ -1,0 +1,49 @@
+﻿namespace TraduSquare.Web.Rest.Client;
+
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using RestSharp;
+using TraduSquare.Web.Rest.Projects;
+
+public class ProjectHandler
+{
+    private readonly RestClient client;
+
+    internal ProjectHandler(RestClient client)
+    {
+        this.client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    public async Task<CreateProjectResponse?> CreateAsync(CreateProjectRequest project)
+    {
+        var request = new RestRequest("/projects", Method.Post)
+            .AddJsonBody(project)
+            .AddOrUpdateHeader("content-type", "application/json");
+        return await client.PostAsync<CreateProjectResponse?>(request);
+        
+    }
+
+    public async Task<IEnumerable<CreateProjectResponse>> GetAll()
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<CreateProjectResponse?> Get(string projectUrl)
+    {
+        throw new NotImplementedException();
+    }
+
+    private async Task<T?> ExecuteVerbose<T>(string resource, Method method)
+    {
+        var request = new RestRequest(resource, method);
+        var response = await client.ExecuteAsync(request).ConfigureAwait(false);
+
+        var statusCode = response.StatusCode;
+        string content = response.Content;
+
+        response.ThrowIfError();
+        T? output = JsonSerializer.Deserialize<T>(response.Content ?? "{}");
+        return output;
+    }
+}

--- a/tools/TraduSquare.Web.Rest.Client/ProjectHandler.cs
+++ b/tools/TraduSquare.Web.Rest.Client/ProjectHandler.cs
@@ -15,26 +15,31 @@ public class ProjectHandler
         this.client = client ?? throw new ArgumentNullException(nameof(client));
     }
 
-    public async Task<CreateProjectResponse?> CreateAsync(CreateProjectRequest project)
+    public async Task<CreateProjectResponse> CreateAsync(CreateProjectRequest project)
     {
         var request = new RestRequest("/projects", Method.Post)
             .AddJsonBody(project)
             .AddOrUpdateHeader("content-type", "application/json");
-        return await client.PostAsync<CreateProjectResponse?>(request);
+        return await client.PostAsync<CreateProjectResponse?>(request)
+            ?? throw new InvalidOperationException("Invalid server response");
         
     }
 
-    public async Task<IndexProjectResponse?> GetAll()
+    public async Task<IndexProjectResponse> GetAll()
     {
         var request = new RestRequest("/projects", Method.Get);
-        return await client.GetAsync<IndexProjectResponse?>(request);
+        return await client.GetAsync<IndexProjectResponse?>(request)
+            ?? throw new InvalidOperationException("Invalid server response");
     }
 
-    public async Task<CreateProjectResponse?> Get(string projectUrl)
+    public async Task<GetProjectResponse> Get(string projectUrl)
     {
-        throw new NotImplementedException();
+        var request = new RestRequest("/projects/" + projectUrl, Method.Get);
+        return await client.GetAsync<GetProjectResponse?>(request)
+            ?? throw new InvalidOperationException("Invalid server response");
     }
 
+#if false
     private async Task<T?> ExecuteVerbose<T>(string resource, Method method)
     {
         var request = new RestRequest(resource, method);
@@ -47,4 +52,5 @@ public class ProjectHandler
         T? output = JsonSerializer.Deserialize<T>(response.Content ?? "{}");
         return output;
     }
+#endif
 }

--- a/tools/TraduSquare.Web.Rest.Client/ProjectHandler.cs
+++ b/tools/TraduSquare.Web.Rest.Client/ProjectHandler.cs
@@ -17,6 +17,26 @@ public class ProjectHandler
 
     public async Task<CreateProjectResponse> CreateAsync(CreateProjectRequest project)
     {
+        // The backend doesn't like empty values
+        if (string.IsNullOrEmpty(project.Project.TechnicalInfo)) {
+            project.Project.TechnicalInfo = null;
+        }
+        if (string.IsNullOrEmpty(project.Project.Team)) {
+            project.Project.Team = null;
+        }
+        if (string.IsNullOrEmpty(project.Project.Description)) {
+            project.Project.Description = null;
+        }
+        if (string.IsNullOrEmpty(project.Project.AdditionalInfo)) {
+            project.Project.AdditionalInfo = null;
+        }
+        if (string.IsNullOrEmpty(project.Project.BuyLink)) {
+            project.Project.BuyLink = null;
+        }
+        if (string.IsNullOrEmpty(project.Project.Download)) {
+            project.Project.Download = null;
+        }
+
         var request = new RestRequest("/projects", Method.Post)
             .AddJsonBody(project)
             .AddOrUpdateHeader("content-type", "application/json");

--- a/tools/TraduSquare.Web.Rest.Client/TraduSquare.Web.Rest.Client.csproj
+++ b/tools/TraduSquare.Web.Rest.Client/TraduSquare.Web.Rest.Client.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RestSharp" Version="111.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TraduSquare.Web.Rest\TraduSquare.Web.Rest.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/TraduSquare.Web.Rest.Client/TraduSquareRestClient.cs
+++ b/tools/TraduSquare.Web.Rest.Client/TraduSquareRestClient.cs
@@ -1,0 +1,27 @@
+﻿namespace TraduSquare.Web.Rest.Client;
+
+using System.Text.Json;
+using RestSharp;
+using RestSharp.Serializers.Json;
+
+public class TraduSquareRestClient
+{
+    public TraduSquareRestClient(string baseUrl, string token)
+    {
+        var options = new RestClientOptions(baseUrl);
+
+        var jsonOptions = new JsonSerializerOptions {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        };
+        var client = new RestClient(
+            options,
+            configureSerialization: s => s.UseSystemTextJson(jsonOptions));
+
+        // TEMP: workaround until the API supports login
+        client.AddDefaultHeader("Authorization", token);
+
+        Projects = new ProjectHandler(client);
+    }
+
+    public ProjectHandler Projects { get; }
+}

--- a/tools/TraduSquare.Web.Rest.Client/TraduSquareRestClient.cs
+++ b/tools/TraduSquare.Web.Rest.Client/TraduSquareRestClient.cs
@@ -1,6 +1,7 @@
 ﻿namespace TraduSquare.Web.Rest.Client;
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using RestSharp;
 using RestSharp.Serializers.Json;
 
@@ -12,6 +13,7 @@ public class TraduSquareRestClient
 
         var jsonOptions = new JsonSerializerOptions {
             PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         };
         var client = new RestClient(
             options,

--- a/tools/TraduSquare.Web.Rest.sln
+++ b/tools/TraduSquare.Web.Rest.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TraduSquare.Web.WordpressMigrator", "TraduSquare.Web.WordpressMigrator\TraduSquare.Web.WordpressMigrator.csproj", "{6F1BBE33-6E61-4CB7-A4FC-ECDC400A503C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TraduSquare.Web.Rest", "TraduSquare.Web.Rest\TraduSquare.Web.Rest.csproj", "{13D8EFD7-54DD-4DE4-AE19-1E314748F238}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TraduSquare.Web.Rest.Client", "TraduSquare.Web.Rest.Client\TraduSquare.Web.Rest.Client.csproj", "{5447EC8A-1E6B-420F-AA28-C54471F905A7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6F1BBE33-6E61-4CB7-A4FC-ECDC400A503C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F1BBE33-6E61-4CB7-A4FC-ECDC400A503C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F1BBE33-6E61-4CB7-A4FC-ECDC400A503C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F1BBE33-6E61-4CB7-A4FC-ECDC400A503C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13D8EFD7-54DD-4DE4-AE19-1E314748F238}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13D8EFD7-54DD-4DE4-AE19-1E314748F238}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13D8EFD7-54DD-4DE4-AE19-1E314748F238}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13D8EFD7-54DD-4DE4-AE19-1E314748F238}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5447EC8A-1E6B-420F-AA28-C54471F905A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5447EC8A-1E6B-420F-AA28-C54471F905A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5447EC8A-1E6B-420F-AA28-C54471F905A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5447EC8A-1E6B-420F-AA28-C54471F905A7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C29C6B6C-B004-43DD-B921-E6392DB5F9BF}
+	EndGlobalSection
+EndGlobal

--- a/tools/TraduSquare.Web.Rest/Projects/CreateProjectRequest.cs
+++ b/tools/TraduSquare.Web.Rest/Projects/CreateProjectRequest.cs
@@ -11,5 +11,15 @@ public class CreateProjectInfo
 
     public required string Slug { get; set; }
 
-    public required string Description { get; set; }
+    public string? TechnicalInfo { get; set; }
+
+    public string? Description { get; set; }
+
+    public string? Team { get; set; }
+
+    public string? Download { get; set; }
+
+    public string? AdditionalInfo { get; set; }
+
+    public string? BuyLink { get; set; }
 }

--- a/tools/TraduSquare.Web.Rest/Projects/CreateProjectRequest.cs
+++ b/tools/TraduSquare.Web.Rest/Projects/CreateProjectRequest.cs
@@ -1,0 +1,15 @@
+﻿namespace TraduSquare.Web.Rest.Projects;
+
+public class CreateProjectRequest
+{
+    public required CreateProjectInfo Project { get; init; }
+}
+
+public class CreateProjectInfo
+{
+    public required string Title { get; set; }
+
+    public required string Slug { get; set; }
+
+    public required string Description { get; set; }
+}

--- a/tools/TraduSquare.Web.Rest/Projects/CreateProjectResponse.cs
+++ b/tools/TraduSquare.Web.Rest/Projects/CreateProjectResponse.cs
@@ -1,0 +1,17 @@
+﻿namespace TraduSquare.Web.Rest.Projects;
+
+public record CreateProjectResponse
+{
+    public int Id { get; set; }
+    public required string Title { get; set; }
+    public required string Slug { get; set; }
+    public string? TechnicalInfo { get; set; }
+    public string? Description { get; set; }
+    public string? Team { get; set; }
+    public string? Download { get; set; }
+    public string? AdditionalInfo { get; set; }
+    public string? BuyLink { get; set; }
+    public string? CreatedAt { get; set; }
+    public string? UpdatedAt { get; set; }
+    public string? Uuid { get; set; }
+}

--- a/tools/TraduSquare.Web.Rest/Projects/GetProjectResponse.cs
+++ b/tools/TraduSquare.Web.Rest/Projects/GetProjectResponse.cs
@@ -1,0 +1,17 @@
+﻿namespace TraduSquare.Web.Rest.Projects;
+
+public record GetProjectResponse
+{
+    public int Id { get; set; } = -1;
+    public string Title { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+    public string? TechnicalInfo { get; set; }
+    public string? Description { get; set; }
+    public string? Team { get; set; }
+    public string? Download { get; set; }
+    public string? AdditionalInfo { get; set; }
+    public string? BuyLink { get; set; }
+    public string? CreatedAt { get; set; }
+    public string? UpdatedAt { get; set; }
+    public string Uuid { get; set; } = string.Empty;
+}

--- a/tools/TraduSquare.Web.Rest/Projects/IndexProjectResponse.cs
+++ b/tools/TraduSquare.Web.Rest/Projects/IndexProjectResponse.cs
@@ -1,6 +1,12 @@
 ﻿namespace TraduSquare.Web.Rest.Projects;
 
-public record CreateProjectResponse
+using System.Collections.ObjectModel;
+
+public class IndexProjectResponse : Collection<IndexProjectInfo>
+{
+}
+
+public record IndexProjectInfo
 {
     public int Id { get; set; } = -1;
     public string Title { get; set; } = string.Empty;

--- a/tools/TraduSquare.Web.Rest/TraduSquare.Web.Rest.csproj
+++ b/tools/TraduSquare.Web.Rest/TraduSquare.Web.Rest.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/tools/TraduSquare.Web.WordpressMigrator/CollectionExtensions.cs
+++ b/tools/TraduSquare.Web.WordpressMigrator/CollectionExtensions.cs
@@ -1,0 +1,14 @@
+﻿namespace TraduSquare.Web.WordpressMigrator;
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+internal static class CollectionExtensions
+{
+    public static void AddRange<T>(this Collection<T> collection, IEnumerable<T> values)
+    {
+        foreach (T value in values) {
+            collection.Add(value);
+        }
+    }
+}

--- a/tools/TraduSquare.Web.WordpressMigrator/Program.cs
+++ b/tools/TraduSquare.Web.WordpressMigrator/Program.cs
@@ -1,0 +1,17 @@
+﻿using TraduSquare.Web.Rest.Client;
+using TraduSquare.Web.Rest.Projects;
+
+Console.WriteLine("Hello");
+
+const string Token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUcmFkdVNxdWFyZSIsImlhdCI6MTcxNjU4NjU3MiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiam9ndWVyc2FuQGdtYWlsLmNvbSIsIkdpdmVuTmFtZSI6IkpvcmdlIiwiU3VybmFtZSI6Ikd1ZXJyYSIsIkVtYWlsIjoiam9ndWVyc2FuQGdtYWlsLmNvbSIsIlJvbGVzIjpbIlJlYWQiLCJXcml0ZSJdfQ.qjZDtWWlNBKVtTcHI4gsqdeTlgyYsV1MXZsVOiwH5sU";
+var client = new TraduSquareRestClient("http://localhost:2300", Token);
+
+var projectInfo = new CreateProjectRequest {
+    Project = new CreateProjectInfo {
+        Title = "Pokémon Conqueset",
+        Slug = "pokemon-conquest",
+        Description = "Cool game",
+    },
+};
+CreateProjectResponse? response = await client.Projects.CreateAsync(projectInfo);
+Console.WriteLine(response);

--- a/tools/TraduSquare.Web.WordpressMigrator/Program.cs
+++ b/tools/TraduSquare.Web.WordpressMigrator/Program.cs
@@ -1,11 +1,12 @@
 ﻿using TraduSquare.Web.Rest.Client;
 using TraduSquare.Web.Rest.Projects;
 
-Console.WriteLine("Hello");
-
+Console.WriteLine("Initializing client");
 const string Token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUcmFkdVNxdWFyZSIsImlhdCI6MTcxNjU4NjU3MiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoiam9ndWVyc2FuQGdtYWlsLmNvbSIsIkdpdmVuTmFtZSI6IkpvcmdlIiwiU3VybmFtZSI6Ikd1ZXJyYSIsIkVtYWlsIjoiam9ndWVyc2FuQGdtYWlsLmNvbSIsIlJvbGVzIjpbIlJlYWQiLCJXcml0ZSJdfQ.qjZDtWWlNBKVtTcHI4gsqdeTlgyYsV1MXZsVOiwH5sU";
 var client = new TraduSquareRestClient("http://localhost:2300", Token);
 
+Console.WriteLine();
+Console.WriteLine("Creating new project");
 var projectInfo = new CreateProjectRequest {
     Project = new CreateProjectInfo {
         Title = "Pokémon Conqueset",
@@ -15,3 +16,10 @@ var projectInfo = new CreateProjectRequest {
 };
 CreateProjectResponse? response = await client.Projects.CreateAsync(projectInfo);
 Console.WriteLine(response);
+
+Console.WriteLine();
+Console.WriteLine("Retrieving all projects...");
+IndexProjectResponse? projects = await client.Projects.GetAll();
+foreach (IndexProjectInfo project in projects ?? []) {
+    Console.WriteLine("  - [{0}] {1} ({2})", project.Id, project.Title, project.Slug);
+}

--- a/tools/TraduSquare.Web.WordpressMigrator/Program.cs
+++ b/tools/TraduSquare.Web.WordpressMigrator/Program.cs
@@ -14,12 +14,17 @@ var projectInfo = new CreateProjectRequest {
         Description = "Cool game",
     },
 };
-CreateProjectResponse? response = await client.Projects.CreateAsync(projectInfo);
+CreateProjectResponse response = await client.Projects.CreateAsync(projectInfo);
 Console.WriteLine(response);
 
 Console.WriteLine();
+Console.WriteLine("Retrieving created project");
+GetProjectResponse projectCreated = await client.Projects.Get(projectInfo.Project.Slug);
+Console.WriteLine(projectCreated);
+
+Console.WriteLine();
 Console.WriteLine("Retrieving all projects...");
-IndexProjectResponse? projects = await client.Projects.GetAll();
-foreach (IndexProjectInfo project in projects ?? []) {
+IndexProjectResponse projects = await client.Projects.GetAll();
+foreach (IndexProjectInfo project in projects) {
     Console.WriteLine("  - [{0}] {1} ({2})", project.Id, project.Title, project.Slug);
 }

--- a/tools/TraduSquare.Web.WordpressMigrator/Program.cs
+++ b/tools/TraduSquare.Web.WordpressMigrator/Program.cs
@@ -3,13 +3,21 @@ using TraduSquare.Web.Rest.Client;
 using TraduSquare.Web.Rest.Projects;
 using TraduSquare.Web.WordpressMigrator.Wrx;
 
-if (args.Length != 1 || !File.Exists(args[0])) {
-    Console.Error.WriteLine("Missing argument or file does not exist");
-    Console.Error.WriteLine("USAGE: WordpressMigrator.exe <WRX_PATH>");
+if (args.Length < 1) {
+    Console.Error.WriteLine("Missing host argument");
+    Console.Error.WriteLine("USAGE: WordpressMigrator.exe <host:port> <WRX_PATH>");
     Environment.Exit(1);
 }
 
-string wordpressXmlPath = args[0];
+string backendHost = args[0];
+
+if (args.Length < 2 || !File.Exists(args[1])) {
+    Console.Error.WriteLine("Missing argument or file does not exist");
+    Console.Error.WriteLine("USAGE: WordpressMigrator.exe <host:port> <WRX_PATH>");
+    Environment.Exit(1);
+}
+
+string wordpressXmlPath = args[1];
 
 string? token = Environment.GetEnvironmentVariable("TS_CLIENT_TOKEN");
 if (string.IsNullOrEmpty(token)) {
@@ -18,7 +26,7 @@ if (string.IsNullOrEmpty(token)) {
     Environment.Exit(2);
 }
 
-var client = new TraduSquareRestClient("http://localhost:2300", token);
+var client = new TraduSquareRestClient(backendHost, token);
 var parser = new WrxTraduSquareProjectParser(wordpressXmlPath);
 
 Stopwatch timer = Stopwatch.StartNew();

--- a/tools/TraduSquare.Web.WordpressMigrator/TraduSquare.Web.WordpressMigrator.csproj
+++ b/tools/TraduSquare.Web.WordpressMigrator/TraduSquare.Web.WordpressMigrator.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TraduSquare.Web.Rest.Client\TraduSquare.Web.Rest.Client.csproj" />
+    <ProjectReference Include="..\TraduSquare.Web.Rest\TraduSquare.Web.Rest.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/TraduSquare.Web.WordpressMigrator/Wrx/TraduSquareProjectInfo.cs
+++ b/tools/TraduSquare.Web.WordpressMigrator/Wrx/TraduSquareProjectInfo.cs
@@ -1,0 +1,51 @@
+﻿namespace TraduSquare.Web.WordpressMigrator.Wrx;
+
+using System;
+using System.Collections.ObjectModel;
+
+internal record TraduSquareProjectInfo
+{
+    public string? Title { get; internal set; }
+
+    public string? Link { get; internal set; }
+
+    public string? Slug { get; internal set; }
+
+    public DateTimeOffset PublicationDate { get; internal set; }
+
+    public string? Creator { get; internal set; }
+
+    public int Id { get; internal set; }
+
+    public DateTimeOffset PostDate { get; internal set; }
+
+    public DateTimeOffset LastModifiedDate { get; internal set; }
+
+    public string? PostStatus { get; internal set; }
+
+    public string? CardInfo { get; internal set; }
+
+    public string? AdditionalInfo { get; internal set; }
+
+    public string? Team { get; internal set; }
+
+    public string? Synopsis { get; internal set; }
+
+    public Collection<string> Screenshots { get; init; } = [];
+
+    public Collection<TraduSquareProjectProgress> Progress { get; init; } = [];
+
+    public string? BuyInfo { get; internal set; }
+
+    public string? PatchDownloadInfo { get; internal set; }
+
+    public string? ProjectStatus { get; internal set; }
+
+    public Collection<TraduSquareProjectPlatformStatus> ProjectStatusPerPlatform { get; init; } = [];
+
+    public string? TargetPlatforms { get; internal set; }
+
+    public Collection<string> TargetLanguages { get; init; } = [];
+
+    public string? SeoSummary { get; internal set; }
+}

--- a/tools/TraduSquare.Web.WordpressMigrator/Wrx/TraduSquareProjectPlatformStatus.cs
+++ b/tools/TraduSquare.Web.WordpressMigrator/Wrx/TraduSquareProjectPlatformStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace TraduSquare.Web.WordpressMigrator.Wrx;
+
+internal record TraduSquareProjectPlatformStatus
+{
+    public required string Platform { get; init; }
+
+    public required string Status { get; init; }
+}

--- a/tools/TraduSquare.Web.WordpressMigrator/Wrx/TraduSquareProjectProgress.cs
+++ b/tools/TraduSquare.Web.WordpressMigrator/Wrx/TraduSquareProjectProgress.cs
@@ -1,0 +1,8 @@
+﻿namespace TraduSquare.Web.WordpressMigrator.Wrx;
+
+internal record TraduSquareProjectProgress
+{
+    public required string Name { get; init; }
+
+    public required int Percentage { get; init; }
+}

--- a/tools/TraduSquare.Web.WordpressMigrator/Wrx/WrxTraduSquareProjectParser.cs
+++ b/tools/TraduSquare.Web.WordpressMigrator/Wrx/WrxTraduSquareProjectParser.cs
@@ -1,0 +1,186 @@
+﻿namespace TraduSquare.Web.WordpressMigrator.Wrx;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml;
+
+internal class WrxTraduSquareProjectParser
+{
+    private static readonly IFormatProvider DateCulture = new CultureInfo("en-US");
+    private const string PostDateFormat = "yyyy-MM-dd HH:mm:ss";
+    private const string EmptyDate = "0000-00-00 00:00:00";
+    private readonly string xmlPath;
+
+    public WrxTraduSquareProjectParser(string xmlPath)
+    {
+        if (!File.Exists(xmlPath)) {
+            throw new FileNotFoundException("Invalid XML path", xmlPath);
+        }
+
+        this.xmlPath = xmlPath;
+    }
+
+    public IEnumerable<TraduSquareProjectInfo> GetProjects()
+    {
+        using XmlReader reader = XmlReader.Create(xmlPath);
+
+        if (!reader.ReadToFollowing("rss")) {
+            throw new FormatException("Expected root element rss");
+        }
+
+        if (!reader.ReadToDescendant("channel")) {
+            throw new FormatException("Expected element channel");
+        }
+
+        while (reader.ReadToFollowing("item")) {
+            if (TryReadProjectInfo(reader, out TraduSquareProjectInfo projectInfo)) {
+                yield return projectInfo;
+            }
+        }
+    }
+
+    private bool TryReadProjectInfo(XmlReader reader, out TraduSquareProjectInfo project)
+    {
+        reader.Read();
+        project = new TraduSquareProjectInfo();
+
+        while (reader.NodeType != XmlNodeType.EndElement && !reader.EOF) {
+            reader.MoveToContent();
+            if (reader.NodeType == XmlNodeType.EndElement) {
+                break;
+            }
+
+            switch (reader.Name) {
+                case "title":
+                    project.Title = reader.ReadElementContentAsString();
+                    break;
+
+                case "link":
+                    project.Link = reader.ReadElementContentAsString();
+                    break;
+
+                case "pubDate":
+                    string pubDate = reader.ReadElementContentAsString();
+                    pubDate = pubDate.Replace("+0000", "GMT"); // to follow RFC-1123
+                    if (!string.IsNullOrWhiteSpace(pubDate)) {
+                        project.PublicationDate = DateTimeOffset.ParseExact(pubDate, "R", DateCulture);
+                    }
+                    break;
+
+                case "dc:creator":
+                    project.Creator = reader.ReadElementContentAsString();
+                    break;
+
+                case "wp:post_id":
+                    project.Id = reader.ReadElementContentAsInt();
+                    break;
+
+                case "wp:post_date_gmt":
+                    string postDate = reader.ReadElementContentAsString();
+                    if (!string.IsNullOrEmpty(postDate) && postDate != EmptyDate) {
+                        project.PostDate = DateTimeOffset.ParseExact(postDate, PostDateFormat, DateCulture, DateTimeStyles.AssumeUniversal);
+                    }
+                    break;
+
+                case "wp:post_modified_gmt":
+                    string modifiedDate = reader.ReadElementContentAsString();
+                    if (!string.IsNullOrEmpty(modifiedDate) && modifiedDate != EmptyDate) {
+                        project.LastModifiedDate = DateTimeOffset.ParseExact(modifiedDate, PostDateFormat, DateCulture, DateTimeStyles.AssumeUniversal);
+                    }
+                    break;
+
+                case "wp:post_type":
+                    string type = reader.ReadElementContentAsString();
+                    if (type != "proyectos") {
+                        while (reader.NodeType != XmlNodeType.EndElement) {
+                            reader.Skip();
+                        }
+                        reader.Read(); // read end element
+                        return false;
+                    }
+                    break;
+
+                case "wp:post_name":
+                    project.Slug = reader.ReadElementContentAsString();
+                    break;
+
+                case "wp:status":
+                    project.PostStatus = reader.ReadElementContentAsString();
+                    break;
+
+                case "wp:postmeta":
+                    (string metadataKey, string metadataValue) = ReadPostMetadata(reader);
+                    switch (metadataKey) {
+                        case "informacion-de-la-ficha":
+                            project.CardInfo = metadataValue;
+                            break;
+                        case "informacion-adicional":
+                            project.AdditionalInfo = metadataValue;
+                            break;
+                        case "equipo":
+                            project.Team = metadataValue;
+                            break;
+                        case "sinopsis":
+                            project.Synopsis = metadataValue;
+                            break;
+                        case "capturas-de-pantalla":
+                            string[] screenshots = metadataValue.Split(',');
+                            project.Screenshots.AddRange(screenshots);
+                            break;
+                        case "porcentajes":
+                            // TODO: parse structure
+                            break;
+                        case "enlaces-de-compra":
+                            project.BuyInfo = metadataValue;
+                            break;
+                        case "enlaces-del-parche":
+                            project.PatchDownloadInfo = metadataValue;
+                            break;
+                        case "estado-del-proyecto":
+                            project.ProjectStatus = metadataValue;
+                            break;
+                        case "idioma":
+                            // TODO: parse structure
+                            break;
+                        case "plataforma":
+                            // TODO: parse structure
+                            break;
+                        case "plataformas":
+                            // TODO: parse structure
+                            break;
+                        case "_yoast_wpseo_metadesc":
+                            project.SeoSummary = metadataValue;
+                            break;
+                    }
+                    break;
+
+                default:
+                    reader.Skip();
+                    break;
+            }
+        }
+
+        reader.Read();
+        return true;
+    }
+
+    private (string key, string value) ReadPostMetadata(XmlReader reader)
+    {
+        string key = string.Empty;
+        string value = string.Empty;
+
+        reader.Read();
+        while (reader.NodeType != XmlNodeType.EndElement && !reader.EOF) {
+            reader.MoveToContent();
+            if (reader.Name == "wp:meta_key") {
+                key = reader.ReadElementContentAsString();
+            } else if (reader.Name == "wp:meta_value") {
+                value = reader.ReadElementContentAsString();
+            }
+        }
+
+        reader.Read(); // end element
+        return (key, value);
+    }
+}


### PR DESCRIPTION
Implement a small .NET tool that allows to migrate the project information from the existing WordPress site into the new backend. It reads the information from an export of the WordPress site in WRX (XML) format.

As part of the work, I implemented a first .NET client for the backend REST API.
It supports the endpoint `projects` for index, get and create.

The tool needs two arguments:
1. Host of the backend. For instance: `localhost:2300`
2. Path to the WRX file.

It also needs an environment variable with the token for the client. The env var name is `TS_CLIENT_TOKEN`.

## Limitations

There are several fields from the WRX file that are still not parsed. All of them have a custom WordPress json-like structure. As the backend doesn't support these fields yet, it was not implemented.

- plataforma
- plataformas
- porcentajes
- idioma

## Possible improvements

- Refactor the WRX to extract the parsing of common WordPress entries (to reuse for other types of posts like news and groups).
- CI for the .NET tool
- Extract parsing of WRX to make it generic (XML serialization style with attributes)
- Convert to .NET tool
- Finish .NET REST client
- Get client TOKEN by login (or sign up)